### PR TITLE
Rails3 support

### DIFF
--- a/lib/initializer.rb
+++ b/lib/initializer.rb
@@ -1,5 +1,5 @@
 class SexyPgConstraintsRailtie < Rails::Railtie
-  initializer "sexy_pg_constraints.include", :after => :active_record do
+  config.after_initialize do
     ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send(:include, SexyPgConstraints)
   end
 end

--- a/lib/initializer.rb
+++ b/lib/initializer.rb
@@ -1,0 +1,5 @@
+class SexyPgConstraintsRailtie < Rails::Railtie
+  initializer "sexy_pg_constraints.include", :after => :active_record do
+    ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send(:include, SexyPgConstraints)
+  end
+end

--- a/lib/sexy_pg_constraints.rb
+++ b/lib/sexy_pg_constraints.rb
@@ -1,3 +1,4 @@
+require 'initializer'
 require "helpers"
 require "constrainer"
 require "deconstrainer"
@@ -20,5 +21,3 @@ module SexyPgConstraints
     end
   end
 end
-
-ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send(:include, SexyPgConstraints)

--- a/sexy_pg_constraints.gemspec
+++ b/sexy_pg_constraints.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = %q{Use migrations and simple syntax to manage constraints in PostgreSQL DB.}
   s.email = %q{max@bitsonnet.com}
   s.extra_rdoc_files = ["CHANGELOG.rdoc", "README.rdoc", "lib/constrainer.rb", "lib/constraints.rb", "lib/deconstrainer.rb", "lib/helpers.rb", "lib/sexy_pg_constraints.rb"]
-  s.files = ["CHANGELOG.rdoc", "Manifest", "README.rdoc", "Rakefile", "init.rb", "lib/constrainer.rb", "lib/constraints.rb", "lib/deconstrainer.rb", "lib/helpers.rb", "lib/sexy_pg_constraints.rb", "sexy_pg_constraints.gemspec", "test/postgresql_adapter.rb", "test/sexy_pg_constraints_test.rb", "test/support/assert_prohibits_allows.rb", "test/support/database.yml", "test/support/database.yml.example", "test/support/models.rb", "test/test_helper.rb"]
+  s.files = ["CHANGELOG.rdoc", "README.rdoc", "Rakefile", "init.rb", "lib/constrainer.rb", "lib/constraints.rb", "lib/deconstrainer.rb", "lib/helpers.rb", "lib/sexy_pg_constraints.rb", "sexy_pg_constraints.gemspec", "test/postgresql_adapter.rb", "test/sexy_pg_constraints_test.rb", "test/support/assert_prohibits_allows.rb", "test/support/database.yml.example", "test/support/models.rb", "test/test_helper.rb"]
   s.homepage = %q{http://github.com/maxim/sexy_pg_constraints}
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Sexy_pg_constraints", "--main", "README.rdoc"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
This is a real quick change that adds an initializer in the plugin to include SexyPgConstraints after ActiveRecord loads. I didn't check against rails 2.x, but this probably breaks it.
